### PR TITLE
Change threshold with cutoff

### DIFF
--- a/src/bin/vislor.rs
+++ b/src/bin/vislor.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         args.lor
     };
 
-    lor_weights(lor, vbox, args.shape, args.threshold, args.sigma);
+    lor_weights(lor, vbox, args.shape, args.cutoff, args.sigma);
 
     Ok(())
 }
@@ -43,8 +43,8 @@ pub struct Cli {
     sigma: Option<Length>,
 
     /// Ignore voxels with weight below this threshold.
-    #[structopt(short, long)]
-    threshold: Option<Length>,
+    #[structopt(short = "k", long)]
+    cutoff: Option<Ratio>,
 
     /// How to represent voxels. BOX is better for viewing the geometric
     /// weights; BALL is better for viewing TOF weights.

--- a/src/bin/vislor.rs
+++ b/src/bin/vislor.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use structopt::StructOpt;
 
-use petalo::weights::{VoxelBox, Length, LOR};
+use petalo::weights::{VoxelBox, Length, LOR, Ratio};
 use petalo::visualize::{lor_weights, Shape};
 
 use petalo::utils::{parse_triplet, parse_lor};

--- a/src/bin/vislor.rs
+++ b/src/bin/vislor.rs
@@ -42,7 +42,7 @@ pub struct Cli {
     #[structopt(short = "r", long)]
     sigma: Option<Length>,
 
-    /// Ignore voxels with weight below this threshold.
+    /// Ignore voxels with lie further than <cutoff> from TOF peak.
     #[structopt(short = "k", long)]
     cutoff: Option<Ratio>,
 

--- a/src/visualize.rs
+++ b/src/visualize.rs
@@ -7,7 +7,7 @@ use kiss3d::scene::{SceneNode};
 use kiss3d::camera::{ArcBall};
 use na::{Point3, Translation3};
 
-use crate::weights::{Length, VoxelBox, Index3, LOR};
+use crate::weights::{Length, Ratio, VoxelBox, Index3, LOR};
 
 use structopt::clap::arg_enum;
 

--- a/src/visualize.rs
+++ b/src/visualize.rs
@@ -107,9 +107,9 @@ impl Scene {
         }
     }
 
-    pub fn place_voxels(&mut self, shape: Shape, threshold: Option<Length>, sigma: Option<Length>) {
+    pub fn place_voxels(&mut self, shape: Shape, cutoff: Option<Ratio>, sigma: Option<Length>) {
 
-        let active_voxels = self.lor.active_voxels(&self.vbox, threshold, sigma)
+        let active_voxels = self.lor.active_voxels(&self.vbox, cutoff, sigma)
             .collect::<std::collections::HashMap<Index3, Length>>();
 
         let &max_weight = active_voxels
@@ -183,7 +183,7 @@ impl Scene {
                         println!("TODO: Toggle TOF / change sigma");
                     },
                     WindowEvent::Key(Key::T, Action::Press, _) => {
-                        println!("TODO: Toggle / change threshold");
+                        println!("TODO: Toggle / change cutoff");
                     },
                     _ => {}
                 }
@@ -192,9 +192,9 @@ impl Scene {
     }
 }
 
-pub fn lor_weights(lor: LOR, vbox: VoxelBox, shape: Shape, threshold: Option<Length>, sigma: Option<Length>) {
+pub fn lor_weights(lor: LOR, vbox: VoxelBox, shape: Shape, cutoff: Option<Ratio>, sigma: Option<Length>) {
     let mut scene = Scene::new(lor, vbox);
-    scene.place_voxels(shape, threshold, sigma);
+    scene.place_voxels(shape, cutoff, sigma);
     scene.main_loop();
 }
 


### PR DESCRIPTION
The variable `threshold` has been changed with `cutoff` in order to ignore voxels which lie further than `cutoff` from TOF peak.